### PR TITLE
fix 404 broken link

### DIFF
--- a/site/hosting.markdown
+++ b/site/hosting.markdown
@@ -8,4 +8,4 @@ nav_order: 4
 
 # Hosting Faithful archives
 
-You can download and host the faithful archives using any file system data source or HTTP endpoint that supports range requests. To host archives or indexes all you need to do is [generate](/archives/data-prep/) or [download](/rpc-server/old-faithful-net/) Epoch car files or indexes. You can then use the config file syntax or command line to serve these car files.
+You can download and host the faithful archives using any file system data source or HTTP endpoint that supports range requests. To host archives or indexes all you need to do is [generate](/archives/dataprep/) or [download](/rpc-server/old-faithful-net/) Epoch car files or indexes. You can then use the config file syntax or command line to serve these car files.


### PR DESCRIPTION
Fixes this broken link in the [Hosting Page](https://old-faithful.net/archives/hosting/)

<img width="941" alt="image" src="https://github.com/rpcpool/yellowstone-faithful/assets/11887259/20fdba1c-7088-4907-9334-9300311eb5f5">
