### PR TITLE
make NodeReader generic over T: Read to support more than just File streams

### DIFF
--- a/geyser-plugin-runner/src/main.rs
+++ b/geyser-plugin-runner/src/main.rs
@@ -9,6 +9,7 @@ use {
         convert::{TryFrom, TryInto},
         env::args,
         error::Error,
+        io::BufReader,
         str::FromStr,
     },
 };
@@ -17,9 +18,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     let file_path = args().nth(1).expect("no file given");
     let _started_at = std::time::Instant::now();
     let file = std::fs::File::open(file_path)?;
+    let reader = BufReader::with_capacity(8 * 1024 * 1024, file);
     let mut item_index = 0;
     {
-        let mut reader = node::NodeReader::new(file)?;
+        let mut reader = node::NodeReader::new(reader)?;
         let header = reader.read_raw_header()?;
         println!("Header bytes: {:?}", header);
 

--- a/geyser-plugin-runner/src/main.rs
+++ b/geyser-plugin-runner/src/main.rs
@@ -16,9 +16,10 @@ use {
 fn main() -> Result<(), Box<dyn Error>> {
     let file_path = args().nth(1).expect("no file given");
     let _started_at = std::time::Instant::now();
+    let file = std::fs::File::open(file_path)?;
     let mut item_index = 0;
     {
-        let mut reader = node::NodeReader::new(file_path.clone())?;
+        let mut reader = node::NodeReader::new(file)?;
         let header = reader.read_raw_header()?;
         println!("Header bytes: {:?}", header);
 

--- a/geyser-plugin-runner/src/node.rs
+++ b/geyser-plugin-runner/src/node.rs
@@ -462,8 +462,8 @@ impl RawNode {
     }
 }
 
-pub struct NodeReader<T: Read> {
-    reader: BufReader<T>,
+pub struct NodeReader<R: Read> {
+    reader: BufReader<R>,
     header: Vec<u8>,
     item_index: u64,
 }

--- a/geyser-plugin-runner/src/node.rs
+++ b/geyser-plugin-runner/src/node.rs
@@ -7,7 +7,7 @@ use {
     std::{
         error::Error,
         fmt,
-        io::{self, BufReader, Read},
+        io::{self, Read},
         vec::Vec,
     },
 };
@@ -463,17 +463,13 @@ impl RawNode {
 }
 
 pub struct NodeReader<R: Read> {
-    reader: BufReader<R>,
+    reader: R,
     header: Vec<u8>,
     item_index: u64,
 }
 
-impl<T: Read> NodeReader<T> {
-    pub fn new(io: T) -> Result<NodeReader<T>, Box<dyn Error>> {
-        // create a buffered reader over the stream
-        let capacity = 8 * 1024 * 1024;
-        let reader = BufReader::with_capacity(capacity, io);
-
+impl<R: Read> NodeReader<R> {
+    pub fn new(reader: R) -> Result<NodeReader<R>, Box<dyn Error>> {
         let node_reader = NodeReader {
             reader,
             header: vec![],

--- a/geyser-plugin-runner/src/node.rs
+++ b/geyser-plugin-runner/src/node.rs
@@ -7,7 +7,6 @@ use {
     std::{
         error::Error,
         fmt,
-        fs::File,
         io::{self, BufReader, Read},
         vec::Vec,
     },
@@ -463,18 +462,17 @@ impl RawNode {
     }
 }
 
-pub struct NodeReader {
-    reader: BufReader<File>,
+pub struct NodeReader<T: Read> {
+    reader: BufReader<T>,
     header: Vec<u8>,
     item_index: u64,
 }
 
-impl NodeReader {
-    pub fn new(file_path: String) -> Result<NodeReader, Box<dyn Error>> {
-        let file = File::open(file_path)?;
-        // create a buffered reader over the file
+impl<T: Read> NodeReader<T> {
+    pub fn new(io: T) -> Result<NodeReader<T>, Box<dyn Error>> {
+        // create a buffered reader over the stream
         let capacity = 8 * 1024 * 1024;
-        let reader = BufReader::with_capacity(capacity, file);
+        let reader = BufReader::with_capacity(capacity, io);
 
         let node_reader = NodeReader {
             reader,


### PR DESCRIPTION
Justification: there is nothing stopping the original `NodeReader` implementation from supporting other types of io streams, such as network streams, etc., other than the lack of generics. The original `NodeReader` was hard-coded for `std::io::File`, this opens it up to anything that implements `std::io::Read`. Nice clean change. As a consequence, the `NodeReader` itself is now initialized by passing an `io` directly instead of a file path.