### PR TITLE
Fix panic in Rewards.UnmarshalCBOR

### DIFF
--- a/ipld/ipldbindcode/cbor.go
+++ b/ipld/ipldbindcode/cbor.go
@@ -284,7 +284,7 @@ func (x *Rewards) UnmarshalCBOR(data []byte) error {
 		}
 		if hash, ok := dataArr.Get(1); ok {
 			if hash != nil {
-				_hash := int(hash.(uint64))
+				_hash := int(hash.(int64))
 				_hash_ptr := &_hash
 				d.Hash = &_hash_ptr
 			}


### PR DESCRIPTION
I had to patch this up to avoid a panic when running dump-car over https://files.old-faithful.net/600/epoch-600.car

I'm not sure if this is the right fix, so please review carefully 