### PR TITLE
upgrade github actions runner to ubuntu 22

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,4 +1,4 @@
-name: main
+name: Build and publish new release binaries 
 
 on:
   push:


### PR DESCRIPTION
Ubuntu 20 not available anymore
https://github.com/actions/runner-images

Guess the build/release workflow is not starting since it can't find arunner on ubuntu 20

https://github.com/rpcpool/yellowstone-faithful/actions/workflows/build-release.yml