### PR TITLE
fix: not all epoch CAR files compress tx metadata

### DIFF
--- a/geyser-plugin-runner/src/main.rs
+++ b/geyser-plugin-runner/src/main.rs
@@ -95,12 +95,16 @@ fn main() -> Result<(), Box<dyn Error>> {
                                     ))
                                 })?;
 
-                            let decompressed = utils::decompress_zstd(reassembled_metadata.clone()).map_err(|err| {
-                                Box::new(std::io::Error::new(
-                                    std::io::ErrorKind::Other,
-                                    std::format!("Error decompressing metadata: {:?}", err),
-                                ))
-                            })?;
+                            let decompressed = if !reassembled_metadata.is_empty() {
+                                utils::decompress_zstd(reassembled_metadata.clone()).map_err(|err| {
+                                    Box::new(std::io::Error::new(
+                                            std::io::ErrorKind::Other,
+                                            std::format!("Error decompressing metadata: {:?}", err),
+                                    ))
+                                })?
+                            } else {
+                                Default::default()
+                            };
 
                             let metadata: solana_storage_proto::convert::generated::TransactionStatusMeta =
                                 prost_011::Message::decode(decompressed.as_slice()).map_err(|err| {


### PR DESCRIPTION
earlier epochs (e.g. 0) don't have their transaction metadata compressed w/ zstd. this commit skips decompression for metadata that does not start with the zstd magic bytes.