### PR TITLE
add 30s timeout to graceful stop

### DIFF
--- a/grpc-server.go
+++ b/grpc-server.go
@@ -103,7 +103,8 @@ func (me *MultiEpoch) ListenAndServeGRPC(ctx context.Context, listenOn string) e
 		return nil
 	case <-ctx.Done():
 		klog.Info("gRPC server context cancelled, shutting down...")
-		return ctx.Err()
+		// Return nil instead of ctx.Err() to indicate graceful shutdown
+		return nil
 	}
 }
 

--- a/grpc-server.go
+++ b/grpc-server.go
@@ -64,18 +64,18 @@ func (me *MultiEpoch) ListenAndServeGRPC(ctx context.Context, listenOn string) e
 		<-ctx.Done()
 		klog.Info("gRPC server shutting down...")
 		defer klog.Info("gRPC server shut down")
-		
+
 		// Create a timeout context for graceful shutdown
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
-		
+
 		// Use a channel to signal when GracefulStop completes
 		done := make(chan struct{})
 		go func() {
 			grpcServer.GracefulStop()
 			close(done)
 		}()
-		
+
 		// Wait for either graceful shutdown to complete or timeout
 		select {
 		case <-done:
@@ -87,13 +87,13 @@ func (me *MultiEpoch) ListenAndServeGRPC(ctx context.Context, listenOn string) e
 	}()
 
 	klog.Infof("gRPC server starting with telemetry enabled on %s", listenOn)
-	
+
 	// Start the server in a goroutine so we can handle shutdown properly
 	serverErr := make(chan error, 1)
 	go func() {
 		serverErr <- grpcServer.Serve(lis)
 	}()
-	
+
 	// Wait for either server error or context cancellation
 	select {
 	case err := <-serverErr:

--- a/main.go
+++ b/main.go
@@ -69,6 +69,11 @@ func main() {
 	sort.Sort(cli.CommandsByName(app.Commands))
 
 	if err := app.RunContext(ctx, os.Args); err != nil {
+		// Don't treat context cancellation as a fatal error during shutdown
+		if err == context.Canceled {
+			klog.Info("Application shutdown completed")
+			return
+		}
 		klog.Fatal(err)
 	}
 }

--- a/multiepoch.go
+++ b/multiepoch.go
@@ -252,8 +252,15 @@ func (m *MultiEpoch) ListenAndServe(ctx context.Context, listenOn string, lsConf
 		<-ctx.Done()
 		klog.Info("RPC server shutting down...")
 		defer klog.Info("RPC server shut down")
-		if err := s.ShutdownWithContext(ctx); err != nil {
+		
+		// Create a timeout context for shutdown
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		
+		if err := s.ShutdownWithContext(shutdownCtx); err != nil {
 			klog.Errorf("Error while shutting down RPC server: %s", err)
+		} else {
+			klog.Info("RPC server gracefully stopped")
 		}
 	}()
 	ln, err := reuseport.Listen("tcp4", listenOn)

--- a/multiepoch.go
+++ b/multiepoch.go
@@ -252,11 +252,11 @@ func (m *MultiEpoch) ListenAndServe(ctx context.Context, listenOn string, lsConf
 		<-ctx.Done()
 		klog.Info("RPC server shutting down...")
 		defer klog.Info("RPC server shut down")
-		
+
 		// Create a timeout context for shutdown
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
-		
+
 		if err := s.ShutdownWithContext(shutdownCtx); err != nil {
 			klog.Errorf("Error while shutting down RPC server: %s", err)
 		} else {

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -88,10 +88,10 @@ func InitTelemetry(ctx context.Context, serviceName string) (func(), error) {
 
 	klog.Info("Telemetry initialized successfully")
 
-	// Return a cleanup function that uses the original context
+	// Return a cleanup function that uses a background context to avoid cancellation issues
 	return func() {
-		// Use a shorter timeout for telemetry shutdown to avoid blocking the main shutdown
-		shutdownCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		// Use a background context with timeout to avoid being canceled by the main context
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		if err := tp.Shutdown(shutdownCtx); err != nil {
 			klog.Errorf("Error shutting down telemetry provider: %v", err)

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -88,12 +88,15 @@ func InitTelemetry(ctx context.Context, serviceName string) (func(), error) {
 
 	klog.Info("Telemetry initialized successfully")
 
-	// Return a cleanup function
+	// Return a cleanup function that uses the original context
 	return func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		// Use a shorter timeout for telemetry shutdown to avoid blocking the main shutdown
+		shutdownCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 		defer cancel()
-		if err := tp.Shutdown(ctx); err != nil {
+		if err := tp.Shutdown(shutdownCtx); err != nil {
 			klog.Errorf("Error shutting down telemetry provider: %v", err)
+		} else {
+			klog.Info("Telemetry provider shut down successfully")
 		}
 	}, nil
 }


### PR DESCRIPTION
Closes https://github.com/rpcpool/yellowstone-faithful/issues/349

```
I1022 07:04:08.045075   18613 cmd-rpc.go:291] Initialized 867/867 epochs in 506.05872ms
^C
I1022 07:04:09.273964   18613 main.go:32] received interrupt signal
ctx done, shutting down bigcache cleanup routine
I1022 07:04:09.274028   18613 grpc-server.go:105] gRPC server context cancelled, shutting down...
I1022 07:04:09.274068   18613 grpc-server.go:65] gRPC server shutting down...
I1022 07:04:09.274038   18613 multiepoch.go:253] RPC server shutting down...
I1022 07:04:09.274131   18613 telemetry.go:99] Telemetry provider shut down successfully
I1022 07:04:09.274181   18613 grpc-server.go:82] gRPC server gracefully stopped
I1022 07:04:09.274191   18613 grpc-server.go:87] gRPC server shut down
I1022 07:04:09.274198   18613 multiepoch.go:263] RPC server gracefully stopped
I1022 07:04:09.274202   18613 multiepoch.go:203] Closing all epochs...
I1022 07:04:09.274213   18613 multiepoch.go:265] RPC server shut down
root@faithful7:/home/pedro# 

```

Client side sees this:

>  [1]      rpc error: code = Unavailable desc = closing transport due to: connection error: desc = "error reading from server: EOF", received prior goaway: code: NO_ERROR, debug data: "graceful_stop"  

```
KeFR2RzJrcFh6UTZ0a3BXQyorVG9rZW5rZWdRZmVaeWlOd0FKYk5iR0tQRlhDV3VCdmY5U3M2MjNWUTVEQXgBgAHw1gg=",
      "index": "1022"
    }
  ],
  "rewards": "CjsKLEhFTDFVU01aS0FMMm9kcE5CajJvQ2pmZm5GR2FZd21iR215ZXdHdjFlMlRVEPWu7QUY17L57h8gAQ=="
}
ERROR:
  Code: Unavailable
  Message: error reading from server: read tcp 100.66.149.113:50870->10.43.128.233:22222: read: connection reset by peer
