### PR TITLE
fix: remove early deferrals

### DIFF
--- a/grpc-server.go
+++ b/grpc-server.go
@@ -94,8 +94,6 @@ func (multi *MultiEpoch) GetBlock(ctx context.Context, params *old_faithful_grpc
 	defer span.End()
 	span.SetAttributes(attribute.Int64("slot", int64(params.Slot)))
 
-	nogc := DontGC(ctx)
-
 	slot := params.Slot
 	epochNumber := slottools.CalcEpochForSlot(slot)
 	span.SetAttributes(attribute.Int64("epoch_number", int64(epochNumber)))
@@ -219,9 +217,6 @@ func (multi *MultiEpoch) GetBlock(ctx context.Context, params *old_faithful_grpc
 
 	resp := old_faithful_grpc.GetBlockResponse()
 	resp.Slot = uint64(block.Slot)
-	if !nogc {
-		defer old_faithful_grpc.PutBlockResponse(resp) // return to pool
-	}
 
 	hasRewards := block.HasRewards()
 	rewardsCid := block.Rewards.(cidlink.Link).Cid
@@ -269,9 +264,6 @@ func (multi *MultiEpoch) GetBlock(ctx context.Context, params *old_faithful_grpc
 					txResp.Index = ptrToUint64(uint64(pos))
 				}
 				allTransactions = append(allTransactions, txResp)
-				if !nogc {
-					defer old_faithful_grpc.PutTransaction(txResp) // return to pool
-				}
 			}
 		}
 

--- a/tools/run-rpc-server-local.sh
+++ b/tools/run-rpc-server-local.sh
@@ -26,5 +26,5 @@ fi
 EPOCH_DIR=${2:-.}
 
 set -x
-faithful-cli rpc --listen ":7999" \
+./bin/faithful-cli rpc --listen ":7999" --grpc-listen ":7998" \
      ${EPOCH_DIR}/epoch-${EPOCH}.yml


### PR DESCRIPTION
  GetBlock used deferred calls to return pooled BlockResponse and Transaction objects to sync.Pool before gRPC could serialize them. Go's defer executes after the return statement but before control returns
  to the caller, creating a race condition where:
  1. GetBlock builds and returns the response
  2. Deferred PutBlockResponse() calls Reset(), clearing all fields
  3. gRPC framework receives a pointer to the now-empty response
  4. Client receives {}

  StreamBlocks avoided this by using WithDontGC(ctx) and managing pool lifecycle after sending.