### PR TITLE
simplify latency histogram with less buckets

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -139,8 +139,8 @@ var IndexLookupTotal = promauto.NewCounterVec(
 )
 
 var latencyBuckets = []float64{
-	0.05, 0.1, 0.15, 0.2, 0.3, 0.4, 0.5, 
-	0.75, 1, 
+	0.05, 0.1, 0.15, 0.2, 0.3, 0.4, 0.5,
+	0.75, 1,
 	2.5, 5,
 }
 


### PR DESCRIPTION
- Histogram buckets define the upper bound of metrics, so we don't need to define 0

- Lower resolution due to high cardinality (each server is emitting 30k metrics just for the histogram),  reduced from 30 to 11 buckets, should be easier to query larger timeframes

- Even with HDD we serve most requests well under a seconds


Example data from one of the servers

<img width="3886" height="1854" alt="image" src="https://github.com/user-attachments/assets/1cf9f993-db9e-4526-87f2-50b46ba96bfc" />