### PR TITLE
fix(geyser-runner): skip txs whose metadata fails native conversion (…

### DIFF
--- a/geyser-plugin-runner/src/main.rs
+++ b/geyser-plugin-runner/src/main.rs
@@ -115,13 +115,24 @@ fn main() -> Result<(), Box<dyn Error>> {
                                 })?;
 
 
+                            // See issue #374.
                             let as_native_metadata: solana_transaction_status::TransactionStatusMeta =
-                                metadata.try_into().map_err(|err| {
-                                    Box::new(std::io::Error::new(
-                                        std::io::ErrorKind::Other,
-                                        std::format!("Error converting metadata to native: {:?}", err),
-                                    ))
-                                })?;
+                                match metadata.try_into() {
+                                    Ok(m) => m,
+                                    Err(err) => {
+                                        let sig = parsed.signatures.first()
+                                            .map(|s| s.to_string())
+                                            .unwrap_or_else(|| "<unknown>".to_string());
+                                        eprintln!(
+                                            "WARN: skipping tx at slot {} index {:?} sig {}: {:?}",
+                                            block.slot,
+                                            transaction.index,
+                                            sig,
+                                            err,
+                                        );
+                                        return Ok(());
+                                    }
+                                };
 
                             let is_vote = is_simple_vote_transaction(&parsed);
 

--- a/geyser-plugin-runner/tests/metadata_conversion.rs
+++ b/geyser-plugin-runner/tests/metadata_conversion.rs
@@ -1,0 +1,59 @@
+use solana_storage_proto::convert::generated;
+
+fn make_meta_with_err(err_bytes: Vec<u8>) -> generated::TransactionStatusMeta {
+    generated::TransactionStatusMeta {
+        err: Some(generated::TransactionError { err: err_bytes }),
+        fee: 0,
+        pre_balances: vec![],
+        post_balances: vec![],
+        inner_instructions: vec![],
+        inner_instructions_none: true,
+        log_messages: vec![],
+        log_messages_none: true,
+        pre_token_balances: vec![],
+        post_token_balances: vec![],
+        rewards: vec![],
+        loaded_writable_addresses: vec![],
+        loaded_readonly_addresses: vec![],
+        return_data: None,
+        return_data_none: true,
+        compute_units_consumed: None,
+    }
+}
+
+#[test]
+fn malformed_tx_error_returns_err() {
+    let truncated = vec![8u8, 0, 0, 0];
+    let meta = make_meta_with_err(truncated);
+
+    let result: Result<solana_transaction_status::TransactionStatusMeta, _> =
+        meta.try_into();
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn well_formed_meta_converts_ok() {
+    let meta = generated::TransactionStatusMeta {
+        err: None,
+        fee: 5000,
+        pre_balances: vec![1, 2],
+        post_balances: vec![1, 2],
+        inner_instructions: vec![],
+        inner_instructions_none: true,
+        log_messages: vec![],
+        log_messages_none: true,
+        pre_token_balances: vec![],
+        post_token_balances: vec![],
+        rewards: vec![],
+        loaded_writable_addresses: vec![],
+        loaded_readonly_addresses: vec![],
+        return_data: None,
+        return_data_none: true,
+        compute_units_consumed: Some(1234),
+    };
+
+    let result: Result<solana_transaction_status::TransactionStatusMeta, _> =
+        meta.try_into();
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
…#374)

Warn and continue instead of aborting the whole epoch when bincode deserialization of TransactionError fails (e.g. BorshIoError variant change in Agave >= 2.1 vs pinned solana-transaction-status ~2.0.13).