### PR TITLE
fix: jsonParsed ALT account source and omit meta.loadedAddresses

### DIFF
--- a/jsonparsed/transaction-wrapper.go
+++ b/jsonparsed/transaction-wrapper.go
@@ -25,7 +25,7 @@ type AccountKey struct {
 	Writable bool   `json:"writable"`
 }
 
-func FromTransaction(solTx *solana.Transaction) (Transaction, error) {
+func FromTransaction(solTx *solana.Transaction, staticAccountKeyCount int) (Transaction, error) {
 	tx := Transaction{
 		Message: Message{
 			AccountKeys:  make([]AccountKey, len(solTx.Message.AccountKeys)),
@@ -38,10 +38,14 @@ func FromTransaction(solTx *solana.Transaction) (Transaction, error) {
 		if err != nil {
 			return tx, fmt.Errorf("failed to check if account key #%d is writable: %w", i, err)
 		}
+		source := "transaction"
+		if staticAccountKeyCount > 0 && i >= staticAccountKeyCount {
+			source = "lookupTable"
+		}
 		tx.Message.AccountKeys[i] = AccountKey{
 			Pubkey:   accKey.String(),
 			Signer:   solTx.IsSigner(accKey),
-			Source:   "transaction", // TODO: what is this?
+			Source:   source,
 			Writable: isWr,
 		}
 	}

--- a/jsonparsed/transaction-wrapper_test.go
+++ b/jsonparsed/transaction-wrapper_test.go
@@ -1,0 +1,53 @@
+package jsonparsed
+
+import (
+	"testing"
+
+	"github.com/gagliardetto/solana-go"
+)
+
+func TestFromTransaction_AccountKeySource(t *testing.T) {
+	static0 := solana.NewWallet().PublicKey()
+	static1 := solana.NewWallet().PublicKey()
+	loaded0 := solana.NewWallet().PublicKey()
+
+	tx := &solana.Transaction{
+		Message: solana.Message{
+			AccountKeys: solana.PublicKeySlice{static0, static1, loaded0},
+		},
+	}
+
+	got, err := FromTransaction(tx, 2)
+	if err != nil {
+		t.Fatalf("FromTransaction: %v", err)
+	}
+	if len(got.Message.AccountKeys) != 3 {
+		t.Fatalf("expected 3 account keys, got %d", len(got.Message.AccountKeys))
+	}
+	if got.Message.AccountKeys[0].Source != "transaction" {
+		t.Fatalf("static key 0 source = %q, want transaction", got.Message.AccountKeys[0].Source)
+	}
+	if got.Message.AccountKeys[1].Source != "transaction" {
+		t.Fatalf("static key 1 source = %q, want transaction", got.Message.AccountKeys[1].Source)
+	}
+	if got.Message.AccountKeys[2].Source != "lookupTable" {
+		t.Fatalf("loaded key source = %q, want lookupTable", got.Message.AccountKeys[2].Source)
+	}
+}
+
+func TestFromTransaction_LegacyUsesTransactionSource(t *testing.T) {
+	key := solana.NewWallet().PublicKey()
+	tx := &solana.Transaction{
+		Message: solana.Message{
+			AccountKeys: solana.PublicKeySlice{key},
+		},
+	}
+
+	got, err := FromTransaction(tx, 1)
+	if err != nil {
+		t.Fatalf("FromTransaction: %v", err)
+	}
+	if got.Message.AccountKeys[0].Source != "transaction" {
+		t.Fatalf("legacy key source = %q, want transaction", got.Message.AccountKeys[0].Source)
+	}
+}

--- a/solana-tx-meta-parsers/json-protobuf.go
+++ b/solana-tx-meta-parsers/json-protobuf.go
@@ -17,7 +17,7 @@ import (
 // - https://github.com/anza-xyz/agave/blob/master/storage-proto/src/convert.rs
 
 // https://github.com/anza-xyz/agave/blob/046f468d26a551dfd14e4f2af7286abe7e168a19/storage-proto/src/convert.rs#L483
-func ProtobufTransactionStatusMetaToUi(meta *confirmed_block.TransactionStatusMeta) (json.RawMessage, error) {
+func ProtobufTransactionStatusMetaToUi(meta *confirmed_block.TransactionStatusMeta, omitLoadedAddresses bool) (json.RawMessage, error) {
 	// Create a new JSON object
 	// #[serde(rename_all = "camelCase")]
 	resp := jsonbuilder.NewObject()
@@ -308,7 +308,7 @@ func ProtobufTransactionStatusMetaToUi(meta *confirmed_block.TransactionStatusMe
 				}
 			})
 	}
-	{
+	if !omitLoadedAddresses {
 		// .loadedAddresses
 		// #[serde(
 		//     default = "OptionSerializer::skip",

--- a/solana-tx-meta-parsers/json-serde.go
+++ b/solana-tx-meta-parsers/json-serde.go
@@ -16,7 +16,7 @@ import (
 
 // TransactionStatusMeta.MarshalJSON implements the json.Marshaler interface
 // and is used to serialize the TransactionStatusMeta struct into JSON format.
-func SerdeTransactionStatusMetaToUi(meta *transaction_status_meta_serde_agave.StoredTransactionStatusMeta) (json.RawMessage, error) {
+func SerdeTransactionStatusMetaToUi(meta *transaction_status_meta_serde_agave.StoredTransactionStatusMeta, omitLoadedAddresses bool) (json.RawMessage, error) {
 	// Create a new JSON object
 	// #[serde(rename_all = "camelCase")]
 	resp := jsonbuilder.NewObject()
@@ -294,7 +294,7 @@ func SerdeTransactionStatusMetaToUi(meta *transaction_status_meta_serde_agave.St
 			resp.Value("rewards", make([]any, 0))
 		}
 	}
-	{
+	if !omitLoadedAddresses {
 		// .loadedAddresses
 		// #[serde(
 		//     default = "OptionSerializer::skip",

--- a/solana-tx-meta-parsers/json.go
+++ b/solana-tx-meta-parsers/json.go
@@ -63,9 +63,10 @@ func (final *EncodedTransactionWithStatusMeta) ToUi(
 	resp := jsonbuilder.NewObject()
 
 	if final.Meta != nil {
+		omitLoadedAddresses := encoding == solana.EncodingJSONParsed
 		if final.Meta.IsSerde() {
 			metaSerde := final.Meta.GetSerde()
-			rawJsonMeta, err := SerdeTransactionStatusMetaToUi(metaSerde)
+			rawJsonMeta, err := SerdeTransactionStatusMetaToUi(metaSerde, omitLoadedAddresses)
 			if err != nil {
 				return nil, fmt.Errorf("failed to serialize (serde) transaction status meta: %w", err)
 			}
@@ -83,7 +84,7 @@ func (final *EncodedTransactionWithStatusMeta) ToUi(
 		}
 		if final.Meta.IsProtobuf() {
 			metaProtobuf := final.Meta.GetProtobuf()
-			rawJsonMeta, err := ProtobufTransactionStatusMetaToUi(metaProtobuf)
+			rawJsonMeta, err := ProtobufTransactionStatusMetaToUi(metaProtobuf, omitLoadedAddresses)
 			if err != nil {
 				return nil, fmt.Errorf("failed to serialize (protobuf) transaction status meta: %w", err)
 			}
@@ -214,6 +215,7 @@ func (final *EncodedTransactionWithStatusMeta) ToUi(
 			)
 		case solana.EncodingJSONParsed:
 			{
+				staticAccountKeyCount := len(final.Transaction.Message.AccountKeys)
 				if !jsonparsed.IsEnabled() {
 					return nil, fmt.Errorf("unsupported encoding jsonParsed: jsonparsed is not enabled")
 				}
@@ -285,7 +287,7 @@ func (final *EncodedTransactionWithStatusMeta) ToUi(
 					parsedInstructions = append(parsedInstructions, parsedInstructionJSON)
 				}
 
-				parsedTx, err := jsonparsed.FromTransaction(final.Transaction)
+				parsedTx, err := jsonparsed.FromTransaction(final.Transaction, staticAccountKeyCount)
 				if err != nil {
 					return nil, fmt.Errorf("failed to convert transaction to jsonparsed.Transaction: %w", err)
 				}

--- a/solana-tx-meta-parsers/json_meta_loaded_addresses_test.go
+++ b/solana-tx-meta-parsers/json_meta_loaded_addresses_test.go
@@ -1,0 +1,45 @@
+package solanatxmetaparsers
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/rpcpool/yellowstone-faithful/third_party/solana_proto/confirmed_block"
+)
+
+func TestProtobufTransactionStatusMetaToUi_OmitsLoadedAddressesForJsonParsed(t *testing.T) {
+	writable := []byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}
+	readonly := []byte{2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2}
+
+	rawOmit, err := ProtobufTransactionStatusMetaToUi(&confirmed_block.TransactionStatusMeta{
+		LoadedWritableAddresses: [][]byte{writable},
+		LoadedReadonlyAddresses: [][]byte{readonly},
+	}, true)
+	if err != nil {
+		t.Fatalf("omit loaded addresses: %v", err)
+	}
+
+	var omit map[string]any
+	if err := json.Unmarshal(rawOmit, &omit); err != nil {
+		t.Fatalf("unmarshal omit json: %v", err)
+	}
+	if _, ok := omit["loadedAddresses"]; ok {
+		t.Fatalf("expected loadedAddresses omitted, got %#v", omit["loadedAddresses"])
+	}
+
+	rawInclude, err := ProtobufTransactionStatusMetaToUi(&confirmed_block.TransactionStatusMeta{
+		LoadedWritableAddresses: [][]byte{writable},
+		LoadedReadonlyAddresses: [][]byte{readonly},
+	}, false)
+	if err != nil {
+		t.Fatalf("include loaded addresses: %v", err)
+	}
+
+	var include map[string]any
+	if err := json.Unmarshal(rawInclude, &include); err != nil {
+		t.Fatalf("unmarshal include json: %v", err)
+	}
+	if _, ok := include["loadedAddresses"]; !ok {
+		t.Fatalf("expected loadedAddresses present when omitLoadedAddresses=false")
+	}
+}

--- a/solana-tx-meta-parsers/json_protobuf_test.go
+++ b/solana-tx-meta-parsers/json_protobuf_test.go
@@ -72,7 +72,7 @@ func TestProtobufTransactionStatusMetaToUi_DecodesLegacyBorshIoError(t *testing.
 		Err: &confirmed_block.TransactionError{
 			Err: []byte{8, 0, 0, 0, 2, 44, 0, 0, 0},
 		},
-	})
+	}, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -104,7 +104,7 @@ func TestProtobufTransactionStatusMetaToUi_FallsBackForMalformedErrorPayload(t *
 		Err: &confirmed_block.TransactionError{
 			Err: []byte{1},
 		},
-	})
+	}, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Label address lookup table accounts with source lookupTable in jsonParsed transaction.message.accountKeys.
- Omit meta.loadedAddresses when encoding is jsonParsed, matching Agave RPC behavior.
- Fixes #390.

## Test plan
- [x] go test ./jsonparsed ./solana-tx-meta-parsers -run TestFromTransaction|TestProtobufTransactionStatusMetaToUi_OmitsLoadedAddressesForJsonParsed
- [x] go vet ./jsonparsed/... ./solana-tx-meta-parsers/...

Made with [Cursor](https://cursor.com)